### PR TITLE
Module 6: MSG-STORY-002 read conversation — per-scenario TDD commits

### DIFF
--- a/src/messaging/exceptions.py
+++ b/src/messaging/exceptions.py
@@ -8,3 +8,7 @@ class MessageTextRequiredError(Exception):
 
 class UnauthorizedError(Exception):
     pass
+
+
+class NotAParticipantError(Exception):
+    pass

--- a/src/messaging/repository.py
+++ b/src/messaging/repository.py
@@ -20,3 +20,9 @@ class InMemoryMessageRepository:
     def save(self, message: Message) -> Message:
         self._store[message.id] = message
         return message
+
+    def find_by_conversation(self, conversation_id: str) -> list[Message]:
+        return sorted(
+            (m for m in self._store.values() if m.conversation_id == conversation_id),
+            key=lambda m: m.created_at,
+        )

--- a/src/messaging/repository.py
+++ b/src/messaging/repository.py
@@ -12,6 +12,9 @@ class InMemoryConversationRepository:
     def find_by_id(self, conversation_id: str) -> Conversation | None:
         return self._store.get(conversation_id)
 
+    def find_by_participant(self, user_id: str) -> list[Conversation]:
+        return [c for c in self._store.values() if user_id in c.participant_ids]
+
 
 class InMemoryMessageRepository:
     def __init__(self):

--- a/src/messaging/service.py
+++ b/src/messaging/service.py
@@ -46,6 +46,9 @@ class MessagingService:
     def get_conversation(self, conversation_id: str) -> Conversation | None:
         return self._conversations.find_by_id(conversation_id)
 
+    def list_conversations(self, requester_id: str) -> list[Conversation]:
+        return self._conversations.find_by_participant(requester_id)
+
     def get_messages(
         self,
         requester_id: str,

--- a/src/messaging/service.py
+++ b/src/messaging/service.py
@@ -2,6 +2,7 @@ from src.users.service import UserService
 
 from .exceptions import (
     MessageTextRequiredError,
+    NotAParticipantError,
     RecipientNotFoundError,
     UnauthorizedError,
 )
@@ -52,6 +53,9 @@ class MessagingService:
         page: int = 1,
         page_size: int = 50,
     ) -> dict:
+        conversation = self._conversations.find_by_id(conversation_id)
+        if conversation is None or requester_id not in conversation.participant_ids:
+            raise NotAParticipantError("NOT_A_PARTICIPANT")
         all_msgs = self._messages.find_by_conversation(conversation_id)
         start = (page - 1) * page_size
         end = start + page_size

--- a/src/messaging/service.py
+++ b/src/messaging/service.py
@@ -44,3 +44,22 @@ class MessagingService:
 
     def get_conversation(self, conversation_id: str) -> Conversation | None:
         return self._conversations.find_by_id(conversation_id)
+
+    def get_messages(
+        self,
+        requester_id: str,
+        conversation_id: str,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> dict:
+        all_msgs = self._messages.find_by_conversation(conversation_id)
+        start = (page - 1) * page_size
+        end = start + page_size
+        items = all_msgs[start:end]
+        has_next = end < len(all_msgs)
+        return {
+            "items": items,
+            "page": page,
+            "page_size": page_size,
+            "has_next": has_next,
+        }

--- a/tests/messaging/test_read_conversation.py
+++ b/tests/messaging/test_read_conversation.py
@@ -74,3 +74,17 @@ def test_msg_be_002_s2_given_non_participant_when_get_messages_then_forbidden(
     with pytest.raises(NotAParticipantError) as exc:
         messaging.get_messages(requester_id=charlie.id, conversation_id=conversation.id)
     assert "NOT_A_PARTICIPANT" in str(exc.value)
+
+
+def test_msg_be_002_s3_given_user_with_conversations_when_list_then_all_returned(
+    messaging, alice, bob, charlie
+):
+    # GIVEN: alice has conversations with bob and charlie; a third is bob<->charlie
+    conv_ab = messaging.start_conversation(alice.id, bob.id)
+    conv_ac = messaging.start_conversation(alice.id, charlie.id)
+    messaging.start_conversation(bob.id, charlie.id)
+    # WHEN: alice lists her conversations
+    conversations = messaging.list_conversations(alice.id)
+    # THEN: only conversations where alice participates are returned
+    returned_ids = {c.id for c in conversations}
+    assert returned_ids == {conv_ab.id, conv_ac.id}

--- a/tests/messaging/test_read_conversation.py
+++ b/tests/messaging/test_read_conversation.py
@@ -1,0 +1,55 @@
+import pytest
+
+from src.messaging.repository import (
+    InMemoryConversationRepository,
+    InMemoryMessageRepository,
+)
+from src.messaging.service import MessagingService
+from src.users.repository import InMemoryUserRepository
+from src.users.service import UserService
+
+VALID_PASSWORD = "securepassword123"  # pragma: allowlist secret
+
+
+@pytest.fixture
+def user_service():
+    return UserService(InMemoryUserRepository())
+
+
+@pytest.fixture
+def messaging(user_service):
+    return MessagingService(
+        conversations=InMemoryConversationRepository(),
+        messages=InMemoryMessageRepository(),
+        users=user_service,
+    )
+
+
+@pytest.fixture
+def alice(user_service):
+    return user_service.register("alice@example.com", "alice", VALID_PASSWORD)
+
+
+@pytest.fixture
+def bob(user_service):
+    return user_service.register("bob@example.com", "bob", VALID_PASSWORD)
+
+
+def test_msg_be_002_s1_given_participant_when_get_messages_then_sorted_asc_paginated(
+    messaging, alice, bob
+):
+    # GIVEN: alice is a participant; conversation has multiple messages
+    conversation = messaging.start_conversation(alice.id, bob.id)
+    for i in range(3):
+        messaging.send_message(
+            sender_id=alice.id, conversation_id=conversation.id, text=f"m{i}"
+        )
+    # WHEN: alice opens the conversation
+    result = messaging.get_messages(
+        requester_id=alice.id, conversation_id=conversation.id, page=1, page_size=50
+    )
+    # THEN: messages are returned sorted by created_at ASC, paginated
+    assert [m.text for m in result["items"]] == ["m0", "m1", "m2"]
+    assert result["page"] == 1
+    assert result["page_size"] == 50
+    assert result["has_next"] is False

--- a/tests/messaging/test_read_conversation.py
+++ b/tests/messaging/test_read_conversation.py
@@ -1,5 +1,6 @@
 import pytest
 
+from src.messaging.exceptions import NotAParticipantError
 from src.messaging.repository import (
     InMemoryConversationRepository,
     InMemoryMessageRepository,
@@ -35,6 +36,11 @@ def bob(user_service):
     return user_service.register("bob@example.com", "bob", VALID_PASSWORD)
 
 
+@pytest.fixture
+def charlie(user_service):
+    return user_service.register("charlie@example.com", "charlie", VALID_PASSWORD)
+
+
 def test_msg_be_002_s1_given_participant_when_get_messages_then_sorted_asc_paginated(
     messaging, alice, bob
 ):
@@ -53,3 +59,18 @@ def test_msg_be_002_s1_given_participant_when_get_messages_then_sorted_asc_pagin
     assert result["page"] == 1
     assert result["page_size"] == 50
     assert result["has_next"] is False
+
+
+def test_msg_be_002_s2_given_non_participant_when_get_messages_then_forbidden(
+    messaging, alice, bob, charlie
+):
+    # GIVEN: the conversation is between alice and bob; charlie is not a participant
+    conversation = messaging.start_conversation(alice.id, bob.id)
+    messaging.send_message(
+        sender_id=alice.id, conversation_id=conversation.id, text="private"
+    )
+    # WHEN: charlie calls get_messages on that conversation
+    # THEN: NotAParticipantError is raised with code NOT_A_PARTICIPANT
+    with pytest.raises(NotAParticipantError) as exc:
+        messaging.get_messages(requester_id=charlie.id, conversation_id=conversation.id)
+    assert "NOT_A_PARTICIPANT" in str(exc.value)


### PR DESCRIPTION
## Summary
Implements MSG-STORY-002 (read a conversation) with strict one-commit-per-GREEN-scenario discipline.

- S1 messages returned sorted by created_at ASC, paginated (items/page/page_size/has_next)
- S2 non-participant forbidden (NOT_A_PARTICIPANT)
- S3 list user conversations (only conversations where caller is a participant)

Adds `find_by_conversation` / `find_by_participant` to in-memory repos, and `get_messages` / `list_conversations` to MessagingService.

## Test plan
- [x] 29/29 tests pass inside Docker
- [x] pre-commit green on every commit