### PR TITLE
Module 6: MSG-STORY-003 @mentions — per-scenario TDD commits

### DIFF
--- a/src/messaging/models.py
+++ b/src/messaging/models.py
@@ -17,3 +17,10 @@ class Message:
     text: str
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass
+class Mention:
+    message_id: str
+    target_user_id: str
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))

--- a/src/messaging/repository.py
+++ b/src/messaging/repository.py
@@ -1,4 +1,4 @@
-from .models import Conversation, Message
+from .models import Conversation, Mention, Message
 
 
 class InMemoryConversationRepository:
@@ -29,3 +29,15 @@ class InMemoryMessageRepository:
             (m for m in self._store.values() if m.conversation_id == conversation_id),
             key=lambda m: m.created_at,
         )
+
+
+class InMemoryMentionRepository:
+    def __init__(self):
+        self._store: dict[str, Mention] = {}
+
+    def save(self, mention: Mention) -> Mention:
+        self._store[mention.id] = mention
+        return mention
+
+    def find_by_message(self, message_id: str) -> list[Mention]:
+        return [m for m in self._store.values() if m.message_id == message_id]

--- a/src/messaging/service.py
+++ b/src/messaging/service.py
@@ -1,3 +1,5 @@
+import re
+
 from src.users.service import UserService
 
 from .exceptions import (
@@ -6,8 +8,14 @@ from .exceptions import (
     RecipientNotFoundError,
     UnauthorizedError,
 )
-from .models import Conversation, Message
-from .repository import InMemoryConversationRepository, InMemoryMessageRepository
+from .models import Conversation, Mention, Message
+from .repository import (
+    InMemoryConversationRepository,
+    InMemoryMentionRepository,
+    InMemoryMessageRepository,
+)
+
+MENTION_PATTERN = re.compile(r"@(\w+)")
 
 
 class MessagingService:
@@ -16,10 +24,12 @@ class MessagingService:
         conversations: InMemoryConversationRepository,
         messages: InMemoryMessageRepository,
         users: UserService,
+        mentions: InMemoryMentionRepository | None = None,
     ):
         self._conversations = conversations
         self._messages = messages
         self._users = users
+        self._mentions = mentions
 
     def start_conversation(self, user_a_id: str, user_b_id: str) -> Conversation:
         conversation = Conversation(participant_ids=(user_a_id, user_b_id))
@@ -33,7 +43,15 @@ class MessagingService:
         message = Message(
             conversation_id=conversation_id, sender_id=sender_id, text=text
         )
-        return self._messages.save(message)
+        saved = self._messages.save(message)
+        if self._mentions is not None:
+            for handle in MENTION_PATTERN.findall(text):
+                target = self._users.resolve_username(handle)
+                if target is not None:
+                    self._mentions.save(
+                        Mention(message_id=saved.id, target_user_id=target.id)
+                    )
+        return saved
 
     def send_message_to(self, sender_id: str, recipient_id: str, text: str) -> Message:
         if self._users.get_profile(recipient_id) is None:

--- a/src/users/repository.py
+++ b/src/users/repository.py
@@ -14,6 +14,12 @@ class InMemoryUserRepository:
                 return user
         return None
 
+    def find_by_username(self, username: str) -> User | None:
+        for user in self._store.values():
+            if user.username == username:
+                return user
+        return None
+
     def save(self, user: User) -> User:
         self._store[user.email] = user
         return user

--- a/src/users/service.py
+++ b/src/users/service.py
@@ -29,6 +29,9 @@ class UserService:
     def get_profile(self, user_id: str) -> User | None:
         return self._repo.find_by_id(user_id)
 
+    def resolve_username(self, username: str) -> User | None:
+        return self._repo.find_by_username(username)
+
     def update_profile(
         self,
         user_id: str,

--- a/tests/messaging/test_mentions.py
+++ b/tests/messaging/test_mentions.py
@@ -1,0 +1,60 @@
+import pytest
+
+from src.messaging.repository import (
+    InMemoryConversationRepository,
+    InMemoryMentionRepository,
+    InMemoryMessageRepository,
+)
+from src.messaging.service import MessagingService
+from src.users.repository import InMemoryUserRepository
+from src.users.service import UserService
+
+VALID_PASSWORD = "securepassword123"  # pragma: allowlist secret
+
+
+@pytest.fixture
+def user_service():
+    return UserService(InMemoryUserRepository())
+
+
+@pytest.fixture
+def mentions_repo():
+    return InMemoryMentionRepository()
+
+
+@pytest.fixture
+def messaging(user_service, mentions_repo):
+    return MessagingService(
+        conversations=InMemoryConversationRepository(),
+        messages=InMemoryMessageRepository(),
+        users=user_service,
+        mentions=mentions_repo,
+    )
+
+
+@pytest.fixture
+def alice(user_service):
+    return user_service.register("alice@example.com", "alice", VALID_PASSWORD)
+
+
+@pytest.fixture
+def bob(user_service):
+    return user_service.register("bob@example.com", "bob", VALID_PASSWORD)
+
+
+def test_msg_be_003_s1_given_mention_when_send_then_mention_stored(
+    messaging, mentions_repo, alice, bob
+):
+    # GIVEN: alice mentions bob by username in a message
+    conversation = messaging.start_conversation(alice.id, bob.id)
+    # WHEN: the message is sent
+    message = messaging.send_message(
+        sender_id=alice.id,
+        conversation_id=conversation.id,
+        text="hey @bob how are you",
+    )
+    # THEN: a mention row is inserted (message_id, target_user_id)
+    mentions = mentions_repo.find_by_message(message.id)
+    assert len(mentions) == 1
+    assert mentions[0].message_id == message.id
+    assert mentions[0].target_user_id == bob.id

--- a/tests/messaging/test_mentions.py
+++ b/tests/messaging/test_mentions.py
@@ -74,3 +74,20 @@ def test_msg_be_003_s2_given_unknown_handle_when_send_then_silently_ignored(
     # THEN: the message is saved normally, no mention record, no error
     assert message.text == "hey @ghostuser nobody home"
     assert mentions_repo.find_by_message(message.id) == []
+
+
+def test_msg_be_003_s3_given_multiple_mentions_when_send_then_one_row_per_user(
+    messaging, user_service, mentions_repo, alice, bob
+):
+    # GIVEN: message contains two valid @username handles
+    charlie = user_service.register("charlie@example.com", "charlie", VALID_PASSWORD)
+    conversation = messaging.start_conversation(alice.id, bob.id)
+    # WHEN: the message is sent
+    message = messaging.send_message(
+        sender_id=alice.id,
+        conversation_id=conversation.id,
+        text="pairing with @bob and @charlie today",
+    )
+    # THEN: one mention record per resolved user
+    mentions = mentions_repo.find_by_message(message.id)
+    assert {m.target_user_id for m in mentions} == {bob.id, charlie.id}

--- a/tests/messaging/test_mentions.py
+++ b/tests/messaging/test_mentions.py
@@ -58,3 +58,19 @@ def test_msg_be_003_s1_given_mention_when_send_then_mention_stored(
     assert len(mentions) == 1
     assert mentions[0].message_id == message.id
     assert mentions[0].target_user_id == bob.id
+
+
+def test_msg_be_003_s2_given_unknown_handle_when_send_then_silently_ignored(
+    messaging, mentions_repo, alice, bob
+):
+    # GIVEN: the message text contains @nonexistentuser
+    conversation = messaging.start_conversation(alice.id, bob.id)
+    # WHEN: the message is sent
+    message = messaging.send_message(
+        sender_id=alice.id,
+        conversation_id=conversation.id,
+        text="hey @ghostuser nobody home",
+    )
+    # THEN: the message is saved normally, no mention record, no error
+    assert message.text == "hey @ghostuser nobody home"
+    assert mentions_repo.find_by_message(message.id) == []


### PR DESCRIPTION
## Summary
Implements MSG-STORY-003 (mention a user in a message) with per-scenario commits.

- S1 mention detected and stored: regex scans text for `@username`, resolves via Users Service, inserts mention row
- S2 unknown @handle silently ignored (regression guard — behavior covered by S1's resolve/skip)
- S3 multiple mentions → one mention row per resolved user (regression guard — regex findall iterates all)

Adds Mention model, InMemoryMentionRepository, resolve_username on UserService, and MENTION_PATTERN regex handling in MessagingService.send_message.

Honest note: S2 and S3 committed as test-only regression guards because S1's minimal implementation already satisfies both — this is explicit in the commit messages.

## Test plan
- [x] 32/32 tests pass inside Docker
- [x] pre-commit green on every commit